### PR TITLE
Add support for root relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ function resolveModules(options) {
 function moduleResolve(_child, _name) {
   var child = ensurePosix(_child);
   var name = ensurePosix(_name);
+
+  if (child.charAt(0) === '/') {
+    var root = name.split('/')[0];
+    return root + child;
+  }
+
   if (child.charAt(0) !== '.') { return child; }
 
   var parts = child.split('/');

--- a/test.js
+++ b/test.js
@@ -13,6 +13,10 @@ describe('module resolver', function () {
   it('should resolve relative parent', function() {
     expect(moduleResolve('../foo', 'example/bar/baz')).to.eql('example/foo');
   });
+  
+  it('should resolve root relative', function() {
+    expect(moduleResolve('/foo', 'example/bar/baz/boo')).to.eql('example/foo');
+  });
 
   it('should be a pass through if absolute', function() {
     expect(moduleResolve('foo/bar', 'example/')).to.eql('foo/bar');


### PR DESCRIPTION
Open for discussion.

When sharing code between applications, you can't depend on absolute paths for imports as the host namespace might have changed. Therefore, you often must use relative paths.

This is fine for the most part, but when dealing with imports that are multiple levels deep or whose pivot point is at the root of the application, it would be desirable to be able to use root-relative import paths. Not only is it less verbose (`../../../../` vs `/`), but also less brittle, as it won't be prone to breaking whenever you move a file in the hierarchy.

cc @sethkinast