### PR TITLE
Enable parallel transpilation in broccoli-babel-transpiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ function moduleResolve(_child, _name) {
   return parentBase.join('/');
 }
 
-// parallel API - enable parallel babel transpilation using this function
-moduleResolve._parallelAPI = [__dirname, { callback: 'moduleResolve' }];
+// parallel API - enable parallel babel transpilation for the moduleResolve function
+moduleResolve._parallelBabel = { requireFile: __dirname, useMethod: 'moduleResolve' };
 
 module.exports = {
   moduleResolve: moduleResolve,

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ function moduleResolve(_child, _name) {
   return parentBase.join('/');
 }
 
+// parallel API - enable parallel babel transpilation using this function
+moduleResolve._parallelAPI = [__dirname, { callback: 'moduleResolve' }];
+
 module.exports = {
   moduleResolve: moduleResolve,
   resolveModules: resolveModules

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "broccoli-babel-transpiler": "^5.7.1",
     "chai": "^3.0.0",
     "mocha": "^2.2.5"
   },

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect;
 var amd = require('./index');
 var moduleResolve = amd.moduleResolve;
 var resolveModules = amd.resolveModules;
+var ParallelApi = require('broccoli-babel-transpiler/lib/parallel-api');
 
 describe('module resolver', function () {
   it('should resolve relative sibling', function() {
@@ -33,9 +34,19 @@ describe('module resolver', function () {
 });
 
 describe('parallel babel transpilation', function() {
-  it('should be setup correctly', function() {
+  it('is setup correctly', function() {
     expect(moduleResolve._parallelBabel).to.be.an('object');
     expect(moduleResolve._parallelBabel.requireFile).to.eql(__dirname);
     expect(moduleResolve._parallelBabel.useMethod).to.eql('moduleResolve');
+  });
+
+  it('builds', function() {
+    expect(ParallelApi.buildFromParallelApiInfo(moduleResolve._parallelBabel)).to.eql(moduleResolve);
+  });
+
+  it('serializes and deserializes', function() {
+    var options = { resolveModuleSource: moduleResolve };
+    var serializedOptions = ParallelApi.serializeOptions(options);
+    expect(ParallelApi.deserializeOptions(serializedOptions)).to.eql(options);
   });
 });

--- a/test.js
+++ b/test.js
@@ -23,11 +23,20 @@ describe('module resolver', function () {
       return moduleResolve('../../bizz', 'example')
     }).to.throw(/Cannot access parent module of root/);
   });
-  
+
   it('should not throw if specified', function() {
     expect(function() {
       var r = resolveModules({ throwOnRootAccess: false });
       return r('../../bizz', 'example')
     }).to.not.throw(/Cannot access parent module of root/);
+  });
+});
+
+describe('parallel API', function() {
+  it('should be setup correctly', function() {
+    expect(moduleResolve._parallelAPI).to.be.an('array');
+    expect(moduleResolve._parallelAPI.length).to.eql(2);
+    expect(moduleResolve._parallelAPI[0]).to.eql(__dirname);
+    expect(moduleResolve._parallelAPI[1]).to.eql({ callback: 'moduleResolve' });
   });
 });

--- a/test.js
+++ b/test.js
@@ -32,11 +32,10 @@ describe('module resolver', function () {
   });
 });
 
-describe('parallel API', function() {
+describe('parallel babel transpilation', function() {
   it('should be setup correctly', function() {
-    expect(moduleResolve._parallelAPI).to.be.an('array');
-    expect(moduleResolve._parallelAPI.length).to.eql(2);
-    expect(moduleResolve._parallelAPI[0]).to.eql(__dirname);
-    expect(moduleResolve._parallelAPI[1]).to.eql({ callback: 'moduleResolve' });
+    expect(moduleResolve._parallelBabel).to.be.an('object');
+    expect(moduleResolve._parallelBabel.requireFile).to.eql(__dirname);
+    expect(moduleResolve._parallelBabel.useMethod).to.eql('moduleResolve');
   });
 });


### PR DESCRIPTION
I've been working to enable parallel transpilation in `broccoli-babel-transpiler`: https://github.com/babel/broccoli-babel-transpiler/pull/114

This PR enables the moduleResolve function to be parallelized when used with broccoli-babel-transpiler.